### PR TITLE
Create retry implementation for TopicExchange

### DIFF
--- a/src/main/java/com/yonatankarp/rabbit_hole/configs/RabbitHoleConfig.java
+++ b/src/main/java/com/yonatankarp/rabbit_hole/configs/RabbitHoleConfig.java
@@ -1,0 +1,32 @@
+package com.yonatankarp.rabbit_hole.configs;
+
+import com.yonatankarp.rabbit_hole.retry.QueueFactory;
+import com.yonatankarp.rabbit_hole.utils.ContextUtils;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.GenericApplicationContext;
+
+/**
+* The configuration of the library. This class will auto-configure the required beans into the
+* integrator application context for them to use.
+*/
+@Configuration
+public class RabbitHoleConfig {
+
+    @Bean
+    @ConditionalOnClass(GenericApplicationContext.class)
+    ContextUtils contextUtils(final GenericApplicationContext context) {
+        return new ContextUtils(context);
+    }
+
+    @Bean
+    @ConditionalOnClass(ConnectionFactory.class)
+    QueueFactory queueFactory(
+            @Autowired final ContextUtils contextUtils,
+            @Autowired final ConnectionFactory connectionFactory) {
+        return new QueueFactory(contextUtils, connectionFactory);
+    }
+}

--- a/src/main/java/com/yonatankarp/rabbit_hole/exceptions/ExchangeException.java
+++ b/src/main/java/com/yonatankarp/rabbit_hole/exceptions/ExchangeException.java
@@ -1,0 +1,17 @@
+package com.yonatankarp.rabbit_hole.exceptions;
+
+/** An exception that is thrown when the given exchange is not valid. */
+public class ExchangeException extends RuntimeException {
+    private ExchangeException(final String message) {
+        super(message);
+    }
+
+    /**
+    * Throwing ExchangeException exception the proper message for invalid exchange name.
+    *
+    * @throws ExchangeException
+    */
+    public static void invalidExchangeNameException() {
+        throw new ExchangeException("Exchange name cannot be null or empty");
+    }
+}

--- a/src/main/java/com/yonatankarp/rabbit_hole/exceptions/QueueConfigException.java
+++ b/src/main/java/com/yonatankarp/rabbit_hole/exceptions/QueueConfigException.java
@@ -1,0 +1,23 @@
+package com.yonatankarp.rabbit_hole.exceptions;
+
+/** An exception caused by misconfiguration of the queues. */
+public class QueueConfigException extends RuntimeException {
+
+    private QueueConfigException(final String message) {
+        super(message);
+    }
+
+    /** An exception that should be thrown if no queue config was passed to the library */
+    public static void emptyConfigurationException() {
+        throw new QueueConfigException("Queue configurations list must not be null or empty.");
+    }
+
+    /**
+    * An exception that should be thrown when the queue configurations mixing multiple types of
+    * exchanges. (e.g. Topic and Direct)
+    */
+    public static void mixedExchangeTypesException() {
+        throw new QueueConfigException(
+                "Queue configurations list must include only 1 configuration type.");
+    }
+}

--- a/src/main/java/com/yonatankarp/rabbit_hole/retry/QueueConfig.java
+++ b/src/main/java/com/yonatankarp/rabbit_hole/retry/QueueConfig.java
@@ -1,0 +1,4 @@
+package com.yonatankarp.rabbit_hole.retry;
+
+/** An interface represents a queue configuration object for RabbitMQ. */
+public interface QueueConfig {}

--- a/src/main/java/com/yonatankarp/rabbit_hole/retry/QueueFactory.java
+++ b/src/main/java/com/yonatankarp/rabbit_hole/retry/QueueFactory.java
@@ -1,0 +1,97 @@
+package com.yonatankarp.rabbit_hole.retry;
+
+import com.yonatankarp.rabbit_hole.exceptions.ExchangeException;
+import com.yonatankarp.rabbit_hole.exceptions.QueueConfigException;
+import com.yonatankarp.rabbit_hole.retry.topic.TopicQueueConfig;
+import com.yonatankarp.rabbit_hole.retry.topic.TopicRetryBuilder;
+import com.yonatankarp.rabbit_hole.utils.ContextUtils;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+* The interface of the integrators with this library. This factory is the only entry point to the
+* library and it should decide how to instantiate all beans according to the given queue
+* configurations it receives.
+*/
+public class QueueFactory {
+
+    private final ContextUtils contextUtils;
+    private final ConnectionFactory connectionFactory;
+    private final Map<Class<? extends QueueConfig>, RetryBuilder> typeBuilder = new HashMap<>();
+
+    /**
+    * Creates a new QueueFactory object.
+    *
+    * @param contextUtils - application context utilities class to register beans.
+    * @param connectionFactory - rabbitmq connection factory instance
+    */
+    @Autowired
+    public QueueFactory(final ContextUtils contextUtils, final ConnectionFactory connectionFactory) {
+        this.contextUtils = contextUtils;
+        this.connectionFactory = connectionFactory;
+        buildTypeBuilderMapping();
+    }
+
+    private void buildTypeBuilderMapping() {
+        this.typeBuilder.put(
+                TopicQueueConfig.class, new TopicRetryBuilder(contextUtils, connectionFactory));
+    }
+
+    /**
+    * Creates the retry mechanism according to the given configs.
+    *
+    * @param exchangeName - the name of the main exchange to create
+    * @param configs - a list of queues that needs to be created and associated with the exchange
+    * @throws com.yonatankarp.rabbit_hole.exceptions.QueueConfigException - if the configuration list
+    *     is empty, null or mixed of multiple QueueConfig types
+    */
+    public void createQueues(final String exchangeName, final List<? extends QueueConfig> configs) {
+        validateExchangeName(exchangeName);
+        validateConfigs(configs);
+
+        final var clazz = typeBuilder.get(configs.get(0).getClass());
+
+        final var retryBuilder =
+                Optional.ofNullable(clazz)
+                        .orElseThrow(
+                                () ->
+                                        new IllegalArgumentException(
+                                                String.format("Required QueueConfig %s is not supported", clazz)));
+
+        retryBuilder.createQueues(exchangeName, configs);
+    }
+
+    private void validateExchangeName(final String exchangeName) {
+        if (exchangeName == null || exchangeName.isBlank()) {
+            ExchangeException.invalidExchangeNameException();
+        }
+    }
+
+    private void validateConfigs(final List<? extends QueueConfig> configs) {
+        checkIfNullOrEmpty(configs);
+        checkAllConfigsOfSameType(configs);
+    }
+
+    private void checkIfNullOrEmpty(final List<? extends QueueConfig> configs) {
+        if (configs == null || configs.isEmpty()) {
+            QueueConfigException.emptyConfigurationException();
+        }
+    }
+
+    private void checkAllConfigsOfSameType(final List<? extends QueueConfig> configs) {
+        // We do not check for NPE as we assume that checkIfNullOrEmpty() was called beforehand
+        final var firstQueueType = configs.get(0).getClass();
+        final var nonMatchingConfigs =
+                configs.stream()
+                        .filter(queueConfig -> !firstQueueType.equals(queueConfig.getClass()))
+                        .count();
+
+        if (nonMatchingConfigs > 0) {
+            QueueConfigException.mixedExchangeTypesException();
+        }
+    }
+}

--- a/src/main/java/com/yonatankarp/rabbit_hole/retry/RetryBuilder.java
+++ b/src/main/java/com/yonatankarp/rabbit_hole/retry/RetryBuilder.java
@@ -1,0 +1,66 @@
+package com.yonatankarp.rabbit_hole.retry;
+
+import java.util.List;
+
+/** An interface of a retry mechanism builder. */
+public abstract class RetryBuilder {
+
+    /** The suffix attached the name of to each retry queue */
+    public static final String RETRY_QUEUES_SUFFIX = ".retry";
+
+    /** The suffix attached to the name of each dead letter queue */
+    public static final String DEAD_LETTER_QUEUES_SUFFIX = ".dead-letter";
+
+    /** The suffix attached to each binding between the exchange and the main queue */
+    public static final String INCOMING_MESSAGE_BINDING_SUFFIX = "IncomingNewMessages";
+
+    /** The suffix attached to each binding between the queue and the retry queue. */
+    public static final String RETRY_MESSAGE_BINDING_SUFFIX = "MessageToRetryQueue";
+
+    /** The suffix attached to each binding between the retry queue and the exchange. */
+    public static final String TO_MAIN_QUEUE_BINDING_SUFFIX = "AfterRetryMessageBackToMainQueue";
+
+    /** The suffix attached to each binding between the exchange and the dead letter queue. */
+    public static final String DEAD_LETTER_BINDING_SUFFIX = "MessagesToDeadLetterQueue";
+
+    /** The suffix of the RabbitTemplate bean name that will be created for the required exchange. */
+    public static final String DEAD_LETTER_RABBIT_TEMPLATE_BEAN_NAME = "deadLetterRabbitTemplate";
+
+    /** The queue key name to set the exchange. */
+    public static final String DEAD_LETTER_EXCHANGE_KEY = "x-dead-letter-exchange";
+
+    /** The queue key name to set the dead-letter queue. */
+    public static final String DEAD_LETTER_ROUTING_KEY = "x-dead-letter-routing-key";
+
+    /** The queue key name to set the TTL of the queue. */
+    public static final String TIME_TO_LIVE_KEY = "x-message-ttl";
+
+    /** The routing key template for sending a message from the main queue to the retry queue. */
+    public static final String TO_RETRY_QUEUE_ROUTING_KEY_FORMAT = "send-to-retry-queue.%s";
+
+    /**
+    * The routing key template for sending a message from the retry queue back to the main queue
+    * after the TTL was passed.
+    */
+    public static final String TO_MAIN_QUEUE_ROUTING_KEY_FORMAT = "send-to-main-queue.%s";
+
+    /**
+    * The routing key template for sending message to the dead letter queue after the amount of
+    * retries have reached.
+    */
+    public static final String TO_DEAD_LETTER_QUEUE_ROUTING_KEY_FORMAT =
+            "send-to-dead-letter-queue.%s";
+
+    /**
+    * This method generates all the required beans to support the retry mechanism, assign them as
+    * needed, and register them into the application context.
+    *
+    * @param exchangeName - the name of the exchange to build the queues to
+    * @param queueConfigs - a list of 1 or more queues that should be bind to the exchange with the
+    *     retry mechanism.
+    * @throws com.yonatankarp.rabbit_hole.exceptions.QueueConfigException - if the configuration list
+    *     is empty, null or mixed of multiple QueueConfig types
+    */
+    public abstract void createQueues(
+            final String exchangeName, final List<? extends QueueConfig> queueConfigs);
+}

--- a/src/main/java/com/yonatankarp/rabbit_hole/retry/topic/TopicQueueConfig.java
+++ b/src/main/java/com/yonatankarp/rabbit_hole/retry/topic/TopicQueueConfig.java
@@ -1,0 +1,27 @@
+package com.yonatankarp.rabbit_hole.retry.topic;
+
+import com.yonatankarp.rabbit_hole.retry.QueueConfig;
+import lombok.AllArgsConstructor;
+import lombok.ToString;
+import lombok.Value;
+
+/**
+* A class that holds the configuration per queue that needs to be created with a retry mechanism
+* attached to it.
+*/
+@Value
+@ToString
+@AllArgsConstructor
+public class TopicQueueConfig implements QueueConfig {
+    /** The name of the main queue to create. */
+    String queueName;
+
+    /** The routing key for the main queue. */
+    String queueRoutingKey;
+
+    /**
+    * The TTL (time to live) that the message will wait in the retry queue before returning to the
+    * main queue in milliseconds. Once this value is set it cannot be changed.
+    */
+    int retryTTL;
+}

--- a/src/main/java/com/yonatankarp/rabbit_hole/retry/topic/TopicRetryBuilder.java
+++ b/src/main/java/com/yonatankarp/rabbit_hole/retry/topic/TopicRetryBuilder.java
@@ -1,0 +1,135 @@
+package com.yonatankarp.rabbit_hole.retry.topic;
+
+import com.yonatankarp.rabbit_hole.retry.QueueConfig;
+import com.yonatankarp.rabbit_hole.retry.RetryBuilder;
+import com.yonatankarp.rabbit_hole.utils.ContextUtils;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.QueueBuilder;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+
+/** A RabbitMQ Topic exchange retry mechanism builder. */
+@AllArgsConstructor
+public class TopicRetryBuilder extends RetryBuilder {
+
+    private final ContextUtils contextUtil;
+    private final ConnectionFactory connectionFactory;
+
+    @Override
+    public void createQueues(
+            final String exchangeName, final List<? extends QueueConfig> topicQueueConfigs) {
+        final var mainExchange = createTopicExchange(exchangeName);
+        contextUtil.registerTopicExchange(mainExchange);
+
+        // Create the RabbitTemplate for messages that need to be discarded when retry exceeds
+        final var deadLetterQueueRabbitTemplate =
+                createDeadLetterQueueRabbitTemplate(mainExchange.getName());
+        contextUtil.registerRabbitTemplate(
+                DEAD_LETTER_RABBIT_TEMPLATE_BEAN_NAME, deadLetterQueueRabbitTemplate);
+
+        topicQueueConfigs.forEach(
+                topicQueueConfig ->
+                        setupEventsRetryBeans(mainExchange, (TopicQueueConfig) topicQueueConfig));
+    }
+
+    private void setupEventsRetryBeans(
+            final TopicExchange exchange, final TopicQueueConfig topicQueueConfig) {
+
+        final var queueName = topicQueueConfig.getQueueName();
+        final var routingKey = topicQueueConfig.getQueueRoutingKey();
+
+        final var retryQueueName = queueName + RETRY_QUEUES_SUFFIX;
+        final var deadLetterQueueName = queueName + DEAD_LETTER_QUEUES_SUFFIX;
+
+        final var toRetryQueueRoutingKey =
+                String.format(TO_RETRY_QUEUE_ROUTING_KEY_FORMAT, retryQueueName);
+        final var sendToMainQueueRoutingKey =
+                String.format(TO_MAIN_QUEUE_ROUTING_KEY_FORMAT, queueName);
+        final var toDeadLetterQueueRoutingKey =
+                String.format(TO_DEAD_LETTER_QUEUE_ROUTING_KEY_FORMAT, queueName);
+
+        // Main listening queue with dead letter routing to retry queue.
+        final var mainQueue = createQueue(queueName, exchange.getName(), toRetryQueueRoutingKey);
+        contextUtil.registerQueue(mainQueue);
+
+        // Binding in order that we receive the event coming from the exchange in the main queue
+        contextUtil.registerBinding(
+                queueName + INCOMING_MESSAGE_BINDING_SUFFIX,
+                createBinding(mainQueue, exchange, routingKey));
+
+        // Retry queue with dead letter routing back to main queue. The TTL cannot be changed without
+        // recreating existing queues.
+        final Queue retryQueue =
+                createQueue(
+                        retryQueueName,
+                        exchange.getName(),
+                        sendToMainQueueRoutingKey,
+                        topicQueueConfig.getRetryTTL());
+        contextUtil.registerQueue(retryQueue);
+
+        // Binding in order to have the messages ending up in the retry queue.
+        contextUtil.registerBinding(
+                queueName + RETRY_MESSAGE_BINDING_SUFFIX,
+                createBinding(retryQueue, exchange, toRetryQueueRoutingKey));
+
+        // Binding in order to have the message ending up back in main queue to be retried
+        contextUtil.registerBinding(
+                queueName + TO_MAIN_QUEUE_BINDING_SUFFIX,
+                createBinding(mainQueue, exchange, sendToMainQueueRoutingKey));
+
+        // Create dead Letter Queue
+        final var deadLetterQueue = createDeadLetterQueue(deadLetterQueueName);
+        contextUtil.registerQueue(deadLetterQueue);
+
+        // Create binding so message end up in the dead letter queue.
+        contextUtil.registerBinding(
+                queueName + DEAD_LETTER_BINDING_SUFFIX,
+                createBinding(deadLetterQueue, exchange, toDeadLetterQueueRoutingKey));
+    }
+
+    private TopicExchange createTopicExchange(final String exchangeName) {
+        return new TopicExchange(exchangeName);
+    }
+
+    private RabbitTemplate createDeadLetterQueueRabbitTemplate(final String exchangeName) {
+        final RabbitTemplate template = new RabbitTemplate(connectionFactory);
+        template.setExchange(exchangeName);
+        return template;
+    }
+
+    private Queue createQueue(
+            final String name, final String retryExchangeName, final String deadLetterRoutingKey) {
+        return createQueue(name, retryExchangeName, deadLetterRoutingKey, null);
+    }
+
+    private Queue createQueue(
+            final String name,
+            final String retryExchangeName,
+            final String deadLetterRoutingKey,
+            final Integer ttl) {
+        final var queueBuilder =
+                QueueBuilder.durable(name)
+                        .withArgument(DEAD_LETTER_EXCHANGE_KEY, retryExchangeName)
+                        .withArgument(DEAD_LETTER_ROUTING_KEY, deadLetterRoutingKey);
+
+        if (ttl != null) {
+            queueBuilder.withArgument(TIME_TO_LIVE_KEY, ttl);
+        }
+
+        return queueBuilder.build();
+    }
+
+    private Queue createDeadLetterQueue(final String name) {
+        return new Queue(name);
+    }
+
+    private Binding createBinding(
+            final Queue queue, final TopicExchange exchange, final String routingKey) {
+        return BindingBuilder.bind(queue).to(exchange).with(routingKey);
+    }
+}

--- a/src/main/java/com/yonatankarp/rabbit_hole/utils/ContextUtils.java
+++ b/src/main/java/com/yonatankarp/rabbit_hole/utils/ContextUtils.java
@@ -1,0 +1,57 @@
+package com.yonatankarp.rabbit_hole.utils;
+
+import lombok.AllArgsConstructor;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.context.support.GenericApplicationContext;
+
+/** An helper class to register objects into the application context */
+@AllArgsConstructor
+public class ContextUtils {
+
+    private final GenericApplicationContext context;
+
+    /**
+    * Register a given TopicExchange into the context.
+    *
+    * @param exchange - the exchange to register.
+    */
+    public void registerTopicExchange(final TopicExchange exchange) {
+        registerToContext(exchange.getName(), exchange, TopicExchange.class);
+    }
+
+    /**
+    * Register a Queue into the context.
+    *
+    * @param queue - the queue to register.
+    */
+    public void registerQueue(final Queue queue) {
+        registerToContext(queue.getName(), queue, Queue.class);
+    }
+
+    /**
+    * Register a Binding into the context.
+    *
+    * @param beanName - name of the bean to register
+    * @param binding - the binding to register.
+    */
+    public void registerBinding(final String beanName, final Binding binding) {
+        registerToContext(beanName, binding, Binding.class);
+    }
+
+    /**
+    * Register a RabbitTamplte into the context.
+    *
+    * @param beanName - name of the bean to register
+    * @param rabbitTemplate - the template to register.
+    */
+    public void registerRabbitTemplate(final String beanName, final RabbitTemplate rabbitTemplate) {
+        registerToContext(beanName, rabbitTemplate, RabbitTemplate.class);
+    }
+
+    private <T> void registerToContext(final String beanName, final T bean, final Class<T> clazz) {
+        context.registerBean(beanName, clazz, () -> bean);
+    }
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=com.yonatankarp.rabbit_hole.configs.RabbitHoleConfig

--- a/src/test/java/com/yonatankarp/rabbit_hole/SpringbootRabbitmqRetryQueuesApplicationTests.java
+++ b/src/test/java/com/yonatankarp/rabbit_hole/SpringbootRabbitmqRetryQueuesApplicationTests.java
@@ -1,11 +1,25 @@
 package com.yonatankarp.rabbit_hole;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.yonatankarp.rabbit_hole.retry.QueueFactory;
+import com.yonatankarp.rabbit_hole.utils.ContextUtils;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class SpringbootRabbitmqRetryQueuesApplicationTests {
 
+    @Autowired private ContextUtils contextUtils;
+    @Autowired private QueueFactory queueFactory;
+
     @Test
     void contextLoads() {}
+
+    @Test
+    void testAutoConfiguration() {
+        assertNotNull(contextUtils);
+        assertNotNull(queueFactory);
+    }
 }

--- a/src/test/java/com/yonatankarp/rabbit_hole/retry/QueueFactoryTest.java
+++ b/src/test/java/com/yonatankarp/rabbit_hole/retry/QueueFactoryTest.java
@@ -1,0 +1,114 @@
+package com.yonatankarp.rabbit_hole.retry;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.yonatankarp.rabbit_hole.exceptions.ExchangeException;
+import com.yonatankarp.rabbit_hole.exceptions.QueueConfigException;
+import com.yonatankarp.rabbit_hole.retry.topic.TopicQueueConfig;
+import com.yonatankarp.rabbit_hole.utils.ContextUtils;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+
+public class QueueFactoryTest {
+
+    private static final String EXCHANGE_NAME = "testExchange";
+
+    private ContextUtils contextUtils;
+    private ConnectionFactory connectionFactory;
+    private QueueFactory factory;
+
+    @BeforeEach
+    public void setUp() {
+        contextUtils = mock(ContextUtils.class);
+        connectionFactory = mock(ConnectionFactory.class);
+        factory = new QueueFactory(contextUtils, connectionFactory);
+    }
+
+    @Test
+    void testNullExchangeNameThrowsError() {
+        // Given null exchange name and valid queue config
+        final var configs =
+                Collections.singletonList(new TopicQueueConfig("testQueue", "testRoutingKey", 1000));
+
+        // When we cal the factory
+        // Then we expect exception to be thrown
+        assertThrows(ExchangeException.class, () -> factory.createQueues(null, configs));
+    }
+
+    @Test
+    void testExchangeNameIsEmptyStringThrowsError() {
+        // Given empty string as exchange name and valid queue config
+        final var configs =
+                Collections.singletonList(new TopicQueueConfig("testQueue", "testRoutingKey", 1000));
+
+        // When we cal the factory
+        // Then we expect exception to be thrown
+        assertThrows(ExchangeException.class, () -> factory.createQueues("", configs));
+    }
+
+    @Test
+    void testExchangeNameIsOnlySpacesStringThrowsError() {
+        // Given only spaces as exchange name and valid queue config
+        final var configs =
+                Collections.singletonList(new TopicQueueConfig("testQueue", "testRoutingKey", 1000));
+
+        // When we cal the factory
+        // Then we expect exception to be thrown
+        assertThrows(ExchangeException.class, () -> factory.createQueues("   ", configs));
+    }
+
+    @Test
+    void testNullQueueConfigThrowsError() {
+        // Given null queue config list and a valid exchange name
+        // When we call the factory
+        // Then we expect exception to be thrown
+        assertThrows(QueueConfigException.class, () -> factory.createQueues(EXCHANGE_NAME, null));
+    }
+
+    @Test
+    void testMixExchangeTypesThrowsError() {
+        // Given mixed config list
+        final var configs =
+                Arrays.asList(
+                        new TopicQueueConfig("testQueue", "testRoutingKey", 1000), new DummyQueueConfig());
+
+        // When we call the factory
+        // Then we expect exception to be thrown
+        assertThrows(QueueConfigException.class, () -> factory.createQueues(EXCHANGE_NAME, configs));
+    }
+
+    @Test
+    void testUnsupportedTypeThrowsError() {
+        // Given unsupported queue config
+        final var configs = Collections.singletonList(new DummyQueueConfig());
+
+        // When we call the factory
+        // Then we expect exception to be thrown
+        assertThrows(
+                IllegalArgumentException.class, () -> factory.createQueues(EXCHANGE_NAME, configs));
+    }
+
+    @Test
+    void testTopicConfiguration() {
+        // Given a topic queue configuration
+        final var configs =
+                Collections.singletonList(new TopicQueueConfig("testQueue", "testRoutingKey", 1000));
+
+        // When we call the factory
+        factory.createQueues(EXCHANGE_NAME, configs);
+
+        // Then we expect the context utilities class to be called with the main topic exchange
+        // and the retry topic exchange
+        verify(contextUtils, times(1)).registerTopicExchange(any());
+    }
+
+    /** Dummy class that implements the QueueConfig interface. */
+    static class DummyQueueConfig implements QueueConfig {}
+}

--- a/src/test/java/com/yonatankarp/rabbit_hole/retry/topic/TopicRetryBuilderIntegrationTest.java
+++ b/src/test/java/com/yonatankarp/rabbit_hole/retry/topic/TopicRetryBuilderIntegrationTest.java
@@ -1,0 +1,142 @@
+package com.yonatankarp.rabbit_hole.retry.topic;
+
+import static com.yonatankarp.rabbit_hole.retry.RetryBuilder.DEAD_LETTER_BINDING_SUFFIX;
+import static com.yonatankarp.rabbit_hole.retry.RetryBuilder.DEAD_LETTER_EXCHANGE_KEY;
+import static com.yonatankarp.rabbit_hole.retry.RetryBuilder.DEAD_LETTER_QUEUES_SUFFIX;
+import static com.yonatankarp.rabbit_hole.retry.RetryBuilder.DEAD_LETTER_RABBIT_TEMPLATE_BEAN_NAME;
+import static com.yonatankarp.rabbit_hole.retry.RetryBuilder.DEAD_LETTER_ROUTING_KEY;
+import static com.yonatankarp.rabbit_hole.retry.RetryBuilder.INCOMING_MESSAGE_BINDING_SUFFIX;
+import static com.yonatankarp.rabbit_hole.retry.RetryBuilder.RETRY_MESSAGE_BINDING_SUFFIX;
+import static com.yonatankarp.rabbit_hole.retry.RetryBuilder.RETRY_QUEUES_SUFFIX;
+import static com.yonatankarp.rabbit_hole.retry.RetryBuilder.TO_DEAD_LETTER_QUEUE_ROUTING_KEY_FORMAT;
+import static com.yonatankarp.rabbit_hole.retry.RetryBuilder.TO_MAIN_QUEUE_BINDING_SUFFIX;
+import static com.yonatankarp.rabbit_hole.retry.RetryBuilder.TO_MAIN_QUEUE_ROUTING_KEY_FORMAT;
+import static com.yonatankarp.rabbit_hole.retry.RetryBuilder.TO_RETRY_QUEUE_ROUTING_KEY_FORMAT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.yonatankarp.rabbit_hole.utils.ContextUtils;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.ExchangeTypes;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+
+@SpringBootTest
+public class TopicRetryBuilderIntegrationTest {
+
+    private static final String EXCHANGE_NAME = "myExchange";
+    private static final String QUEUE_NAME = "myQueue";
+    private static final String ROUTING_KEY = "my.routing.key";
+
+    @Autowired private ApplicationContext context;
+
+    @Autowired private ContextUtils contextUtil;
+
+    @Autowired private ConnectionFactory connectionFactory;
+
+    private TopicRetryBuilder retryBuilder;
+
+    @BeforeEach
+    void setUp() {
+        retryBuilder = new TopicRetryBuilder(contextUtil, connectionFactory);
+    }
+
+    @Test
+    void testAllBeansAreCorrectlyCreated() {
+        // Given a valid exchange name and topic queue configuration
+        final var configs =
+                Collections.singletonList(new TopicQueueConfig(QUEUE_NAME, ROUTING_KEY, 1000));
+
+        // When we call create method
+        retryBuilder.createQueues(EXCHANGE_NAME, configs);
+
+        // Then we expect the context contains main exchange and its correctly configured
+        final var mainExchange = context.getBean(EXCHANGE_NAME, TopicExchange.class);
+        assertNotNull(mainExchange);
+        assertEquals(mainExchange.getType(), ExchangeTypes.TOPIC);
+
+        // And we expect that the context contains the rabbit template bean and its correctly configured
+        final var deadLetterTemplate =
+                context.getBean(DEAD_LETTER_RABBIT_TEMPLATE_BEAN_NAME, RabbitTemplate.class);
+        assertNotNull(deadLetterTemplate);
+        assertEquals(EXCHANGE_NAME, deadLetterTemplate.getExchange());
+
+        // And we expect that the context contains the main queue and its correctly configured
+        final var mainQueue = context.getBean(QUEUE_NAME, Queue.class);
+        final var mainQueueRoutingKey =
+                String.format(TO_RETRY_QUEUE_ROUTING_KEY_FORMAT, QUEUE_NAME + RETRY_QUEUES_SUFFIX);
+        assertQueue(mainQueue, QUEUE_NAME, mainQueueRoutingKey);
+
+        // And we expect that the context contains the main queue binding and its correctly configured
+        final var mainQueueBinding =
+                context.getBean(QUEUE_NAME + INCOMING_MESSAGE_BINDING_SUFFIX, Binding.class);
+        assertBinding(mainQueueBinding, ROUTING_KEY, QUEUE_NAME);
+
+        // And we expect that the context contains the retry queue and its correctly configured
+        final var retryQueue = context.getBean(QUEUE_NAME + RETRY_QUEUES_SUFFIX, Queue.class);
+        final var retryQueueRoutingKey = String.format(TO_MAIN_QUEUE_ROUTING_KEY_FORMAT, QUEUE_NAME);
+        assertQueue(retryQueue, QUEUE_NAME + RETRY_QUEUES_SUFFIX, retryQueueRoutingKey);
+
+        // And we expect that the context contains the main queue to retry queue binding and its
+        // correctly configured
+        final var toRetryQueueBinding =
+                context.getBean(QUEUE_NAME + RETRY_MESSAGE_BINDING_SUFFIX, Binding.class);
+        assertBinding(
+                toRetryQueueBinding,
+                String.format(TO_RETRY_QUEUE_ROUTING_KEY_FORMAT, QUEUE_NAME + RETRY_QUEUES_SUFFIX),
+                QUEUE_NAME + RETRY_QUEUES_SUFFIX);
+
+        // And we expect that the context contains the retry queue to main queue binding and its
+        // correctly configured
+        final var toMainQueueBinding =
+                context.getBean(QUEUE_NAME + TO_MAIN_QUEUE_BINDING_SUFFIX, Binding.class);
+        assertBinding(
+                toMainQueueBinding,
+                String.format(TO_MAIN_QUEUE_ROUTING_KEY_FORMAT, QUEUE_NAME),
+                QUEUE_NAME);
+
+        // And we expect that the context contains the dead letter queue and it's correctly configured
+        final var deadLetterQueue =
+                context.getBean(QUEUE_NAME + DEAD_LETTER_QUEUES_SUFFIX, Queue.class);
+        assertDeadLetterQueue(deadLetterQueue);
+
+        // And we expect that the context contains the binding to dead letter queue and its correctly
+        // configured
+        final var toDeadLetterQueueBinding =
+                context.getBean(QUEUE_NAME + DEAD_LETTER_BINDING_SUFFIX, Binding.class);
+        assertBinding(
+                toDeadLetterQueueBinding,
+                String.format(TO_DEAD_LETTER_QUEUE_ROUTING_KEY_FORMAT, QUEUE_NAME),
+                QUEUE_NAME + DEAD_LETTER_QUEUES_SUFFIX);
+    }
+
+    private void assertQueue(
+            final Queue actualQueue, final String queueName, final String routingKey) {
+        assertNotNull(actualQueue);
+        assertEquals(queueName, actualQueue.getActualName());
+        assertEquals(EXCHANGE_NAME, actualQueue.getArguments().get(DEAD_LETTER_EXCHANGE_KEY));
+        assertEquals(routingKey, actualQueue.getArguments().get(DEAD_LETTER_ROUTING_KEY));
+    }
+
+    private void assertDeadLetterQueue(final Queue actualQueue) {
+        assertNotNull(actualQueue);
+        assertEquals("myQueue.dead-letter", actualQueue.getActualName());
+    }
+
+    private void assertBinding(
+            final Binding actualBinding, final String routingKey, final String queueName) {
+        assertNotNull(actualBinding);
+        assertEquals(EXCHANGE_NAME, actualBinding.getExchange());
+        assertEquals(routingKey, actualBinding.getRoutingKey());
+        assertEquals(queueName, actualBinding.getDestination());
+        assertEquals(Binding.DestinationType.QUEUE, actualBinding.getDestinationType());
+    }
+}

--- a/src/test/java/com/yonatankarp/rabbit_hole/utils/ContextUtilsIntegrationTest.java
+++ b/src/test/java/com/yonatankarp/rabbit_hole/utils/ContextUtilsIntegrationTest.java
@@ -1,0 +1,86 @@
+package com.yonatankarp.rabbit_hole.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+
+@SpringBootTest
+public class ContextUtilsIntegrationTest {
+
+    @Autowired private ApplicationContext context;
+
+    @Autowired private ContextUtils contextUtils;
+    @Autowired private ConnectionFactory connectionFactory;
+
+    @Test
+    void testRegisterQueue() {
+        // Given a queue
+        final var queue = new Queue("testQueue");
+
+        // When we call registry method
+        contextUtils.registerQueue(queue);
+
+        // Then we expect the queue to be available in the context
+        final var actual = context.getBean("testQueue", Queue.class);
+        assertNotNull(actual);
+        assertEquals(queue.getName(), actual.getName());
+    }
+
+    @Test
+    void testRegisterTopicExchange() {
+        // Given a topic exchange
+        final var exchange = new TopicExchange("testExchange");
+
+        // When we call registry method
+        contextUtils.registerTopicExchange(exchange);
+
+        // Then we expect the correct exchange to be available in the context
+        final var actual = context.getBean("testExchange", TopicExchange.class);
+        assertNotNull(actual);
+        assertEquals(exchange.getName(), actual.getName());
+        assertEquals(exchange.getType(), actual.getType());
+    }
+
+    @Test
+    void testRegisterBinding() {
+        // Given a valid exchange, queue and binding
+        final var queue = new Queue("test");
+        final var exchange = new TopicExchange("testExchange");
+        final var routingKey = "routing-key";
+
+        final var binding = BindingBuilder.bind(queue).to(exchange).with(routingKey);
+
+        // When we call registry method
+        contextUtils.registerBinding("testBinding", binding);
+
+        // Then we expect the queue to be available in the context
+        final var actual = context.getBean("testBinding", Binding.class);
+        assertNotNull(actual);
+        assertEquals(binding.getExchange(), exchange.getName());
+        assertEquals(binding.getRoutingKey(), routingKey);
+    }
+
+    @Test
+    void testRegisterRabbitTemplate() {
+        // Given a rabbit template
+        final var rabbitTemplate = new RabbitTemplate(connectionFactory);
+
+        // When we call registry method
+        contextUtils.registerRabbitTemplate("myRabbitTemplate", rabbitTemplate);
+
+        // Then we expect the queue to be available in the context
+        final var actual = context.getBean("myRabbitTemplate", RabbitTemplate.class);
+        assertNotNull(actual);
+        assertEquals(rabbitTemplate, actual);
+    }
+}


### PR DESCRIPTION
# Purpose

This PR introducing the implementation of the retry mechanism for `TopicExchange` with RabbitMQ.
It's also laying the ground for having more exchanges in the future (`DirectExchange` and `FanoutExchange`)

# Types of changes

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

# Checklist

- [x] Documentation is updated
- [x] All tests pass
- [ ] No new tests needed
- [x] Code is styled
