### PR TITLE
Upgrade to jUnit5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id("jacoco")
     id("com.diffplug.spotless") version "6.0.5" apply true
-    id("org.springframework.boot") version "2.5.5" apply false
+    id("org.springframework.boot") version "2.6.2" apply false
     id("io.spring.dependency-management") version "1.0.11.RELEASE" apply false
     id("io.freefair.lombok") version "6.2.0" apply false
 }

--- a/rabbit-hole/build.gradle
+++ b/rabbit-hole/build.gradle
@@ -29,9 +29,11 @@ bootJar {
 dependencies {
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-amqp'
 
+    // Tests
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.2.0'
 }
 
 build {

--- a/rabbit-hole/src/main/java/com/yonatankarp/rabbit_hole/utils/ContextUtils.java
+++ b/rabbit-hole/src/main/java/com/yonatankarp/rabbit_hole/utils/ContextUtils.java
@@ -7,7 +7,7 @@ import org.springframework.amqp.core.TopicExchange;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.context.support.GenericApplicationContext;
 
-/** An helper class to register objects into the application context */
+/** A helper class to register objects into the application context */
 @AllArgsConstructor
 public class ContextUtils {
 

--- a/rabbit-hole/src/test/java/com/yonatankarp/rabbit_hole/config/ComponentTestConfig.java
+++ b/rabbit-hole/src/test/java/com/yonatankarp/rabbit_hole/config/ComponentTestConfig.java
@@ -1,0 +1,14 @@
+package com.yonatankarp.rabbit_hole.config;
+
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ComponentTestConfig {
+    @Bean
+    ConnectionFactory testing() {
+        return new CachingConnectionFactory();
+    }
+}

--- a/rabbit-hole/src/test/java/com/yonatankarp/rabbit_hole/retry/topic/TopicRetryBuilderIntegrationTest.java
+++ b/rabbit-hole/src/test/java/com/yonatankarp/rabbit_hole/retry/topic/TopicRetryBuilderIntegrationTest.java
@@ -1,5 +1,23 @@
 package com.yonatankarp.rabbit_hole.retry.topic;
 
+import java.util.Collections;
+import com.yonatankarp.rabbit_hole.configs.RabbitHoleConfig;
+import com.yonatankarp.rabbit_hole.config.ComponentTestConfig;
+import com.yonatankarp.rabbit_hole.utils.ContextUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.ExchangeTypes;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
 import static com.yonatankarp.rabbit_hole.retry.RetryBuilder.DEAD_LETTER_BINDING_SUFFIX;
 import static com.yonatankarp.rabbit_hole.retry.RetryBuilder.DEAD_LETTER_EXCHANGE_KEY;
 import static com.yonatankarp.rabbit_hole.retry.RetryBuilder.DEAD_LETTER_QUEUES_SUFFIX;
@@ -15,32 +33,22 @@ import static com.yonatankarp.rabbit_hole.retry.RetryBuilder.TO_RETRY_QUEUE_ROUT
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import com.yonatankarp.rabbit_hole.utils.ContextUtils;
-import java.util.Collections;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.springframework.amqp.core.Binding;
-import org.springframework.amqp.core.ExchangeTypes;
-import org.springframework.amqp.core.Queue;
-import org.springframework.amqp.core.TopicExchange;
-import org.springframework.amqp.rabbit.connection.ConnectionFactory;
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.ApplicationContext;
-
-@SpringBootTest
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {RabbitHoleConfig.class, ComponentTestConfig.class})
 public class TopicRetryBuilderIntegrationTest {
 
     private static final String EXCHANGE_NAME = "myExchange";
     private static final String QUEUE_NAME = "myQueue";
     private static final String ROUTING_KEY = "my.routing.key";
 
-    @Autowired private ApplicationContext context;
+    @Autowired
+    private ApplicationContext context;
 
-    @Autowired private ContextUtils contextUtil;
+    @Autowired
+    private ContextUtils contextUtil;
 
-    @Autowired private ConnectionFactory connectionFactory;
+    @Autowired
+    private ConnectionFactory connectionFactory;
 
     private TopicRetryBuilder retryBuilder;
 


### PR DESCRIPTION
# Purpose

This commit updates the testing framework from `junit4` to `junit5` to fix 2 vulnerabilities that have been detected by synk

# Types of changes

- [ ] Bugfix
- [x] Feature
- [x] Refactoring

# Checklist

- [ ] Documentation is updated
- [x] All tests pass
- [x] No new tests needed
- [x] Code is styled
