### PR TITLE
Fix release flow  to be driven by tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 # This action should be triggered on any PR merge to our main branch
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
 
 jobs:
   artifact:


### PR DESCRIPTION
# Purpose

Change the way release is created back to tagging instead of push to `main` branch.

# Types of changes

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

# Checklist

- [ ] Documentation is updated
- [ ] All tests pass
- [ ] No new tests needed
- [ ] Code is styled
