### PR TITLE
Enable auto merge for dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,32 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: "./build/reports/jacoco/jacocoTestReport.xml"
+
+  dependabot_auto_merge:
+    if: ${{ github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    needs: ci
+    steps:
+      # If the PR is created by Dependabot run additional steps
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.2.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve a Dependabot PR
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+                steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
+        # Approving the PR and waiting for 5 sec to let GitHub UI to reflect the changes
+        run: gh pr review --approve "$PR_URL" && sleep 5
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.REVIEWER_GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+                steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
+        run: gh pr merge --auto --rebase "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Purpose

This commit enables dependabot to auto-merge PRs that passing CI with minor or patch versions

# Types of changes

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

# Checklist

- [ ] Documentation is updated
- [ ] All tests pass
- [x] No new tests needed
- [ ] Code is styled
