### PR TITLE
Update to jvm17

### DIFF
--- a/.github/workflows/check_style.yml
+++ b/.github/workflows/check_style.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Install Java
         uses: actions/setup-java@v3
         with:
-          java-version: 11
-          distribution: 'adopt'
+          java-version: 17
+          distribution: 'temurin'
 
       - name: Git Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Install Java
         uses: actions/setup-java@v3
         with:
-          java-version: 11
-          distribution: 'adopt'
+          java-version: 17
+          distribution: 'temurin'
 
       - name: Git Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ jobs:
       - name: Install Java
         uses: actions/setup-java@v3
         with:
-          java-version: 11
-          distribution: 'adopt'
+          java-version: 17
+          distribution: 'temurin'
 
       - uses: actions/checkout@v3
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .gradle
-/build/
+*/build/*
 !gradle/wrapper/gradle-wrapper.jar
 
 ### STS ###

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The major difference between the solution linked above is that this library is t
 
 ### Built With
 
-* [OpenJDK Java 11](https://openjdk.java.net/projects/jdk/11/)
+* [OpenJDK Java 17](https://openjdk.org/projects/jdk/17/)
 * [Spring Boot](https://spring.io/projects/spring-boot)
 * [Gradle](https://gradle.org/)
 
@@ -87,7 +87,7 @@ To build this library locally follow the steps below:
 
 ### Prerequisites
 
-* Java 11 or newer
+* Java 17 or newer
 * Gradle
 
 ### Installation

--- a/buildSrc/src/main/groovy/rabbit-hole.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/rabbit-hole.java-conventions.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 }
 

--- a/demo-app/README.md
+++ b/demo-app/README.md
@@ -3,7 +3,7 @@ This repository demo how to integrate your SpringBoot application with the ["Rab
 
 ### Built With
 
-* [OpenJDK Java 11](https://openjdk.java.net/projects/jdk/11/)
+* [OpenJDK Java 17](https://openjdk.org/projects/jdk/17/)
 * [Spring Boot](https://spring.io/projects/spring-boot)
 * [Gradle](https://gradle.org/)
 


### PR DESCRIPTION
# Purpose

This commit updates the project to run on top of JVM17 which is the latest stable version of the JVM at this point in time.

This is a required step to upgrade from Spring Boot 2.x.x to Spring Boot 3.x.x

# Types of changes

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

# Checklist

- [x] Documentation is updated
- [x] All tests pass
- [x] No new tests needed
- [x] Code is styled
